### PR TITLE
Implemented minimal syntax highlighting VS Code extension for the Palang programming language

### DIFF
--- a/palang-vs-code-syntax-highlighting/.vscode/launch.json
+++ b/palang-vs-code-syntax-highlighting/.vscode/launch.json
@@ -1,0 +1,17 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			]
+		}
+	]
+}

--- a/palang-vs-code-syntax-highlighting/.vscodeignore
+++ b/palang-vs-code-syntax-highlighting/.vscodeignore
@@ -1,0 +1,4 @@
+.vscode/**
+.vscode-test/**
+.gitignore
+vsc-extension-quickstart.md

--- a/palang-vs-code-syntax-highlighting/CHANGELOG.md
+++ b/palang-vs-code-syntax-highlighting/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Change Log
+
+All notable changes to the Palang extension will be documented in this file.

--- a/palang-vs-code-syntax-highlighting/README.md
+++ b/palang-vs-code-syntax-highlighting/README.md
@@ -1,0 +1,22 @@
+# Palang README
+
+The Palang programming language empowers developers to bootstrap LLM projects quickly and efficiently and to share LLM logic between projects.
+
+This extension provides syntax highlighting for the Palang programming language in Visual Studio Code.
+
+## Features
+- Syntax Highlighting: Enjoy color-coded syntax highlighting for keywords, functions, variables, prompt, model definitions, etc. in Palang.
+- Customizable: Easily customize the color themes to fit your preferences.
+- Support for Placeholders: Highlight placeholders in prompt bodies for better readability.
+
+## Requirements
+- Visual Studio Code: Ensure you have the latest version of VS Code installed.
+
+## Extension Settings
+This extension does not currently contribute any specific settings through the `contributes.configuration` extension point.
+
+## Known Issues
+None to date.
+
+## Release Notes
+1.0.0 - Initial release of the Palang syntax highlighting extension.

--- a/palang-vs-code-syntax-highlighting/language-configuration.json
+++ b/palang-vs-code-syntax-highlighting/language-configuration.json
@@ -1,0 +1,30 @@
+{
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "//",
+        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+        "blockComment": [ "/*", "*/" ]
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    // symbols that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/palang-vs-code-syntax-highlighting/package.json
+++ b/palang-vs-code-syntax-highlighting/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "palang",
+  "displayName": "Palang",
+  "description": "The Palang programming language empowers developers to bootstrap LLM projects quickly and efficiently and to share LLM logic between projects.",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.92.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [{
+      "id": "palang",
+      "aliases": ["Palang", "palang"],
+      "extensions": [".palang",".plg"],
+      "configuration": "./language-configuration.json"
+    }],
+    "grammars": [{
+      "language": "palang",
+      "scopeName": "source.palang",
+      "path": "./syntaxes/palang.tmLanguage.json"
+    }]
+  }
+}

--- a/palang-vs-code-syntax-highlighting/syntaxes/palang.tmLanguage.json
+++ b/palang-vs-code-syntax-highlighting/syntaxes/palang.tmLanguage.json
@@ -1,0 +1,119 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Palang",
+	"patterns": [
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#functions"
+		},
+		{
+			"include": "#variables"
+		},
+		{
+			"include": "#prompt-body"
+		},
+		{
+			"include": "#model-body"
+		}
+	],
+	"repository": {
+		"keywords": {
+			"patterns": [
+				{
+					"name": "keyword.control.palang",
+					"match": "\\b(module|model|prompt|function|return|if|for|in|rag)\\b"
+				}
+			]
+		},
+		"strings": {
+			"name": "string.quoted.double.palang",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.palang",
+					"match": "\\\\."
+				}
+			]
+		},
+		"comments": {
+			"name": "comment.line.double-slash.palang",
+			"match": "//.*$"
+		},
+		"functions": {
+			"patterns": [
+				{
+					"name": "entity.name.function.palang",
+					"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\()"
+				}
+			]
+		},
+		"variables": {
+			"patterns": [
+				{
+					"name": "variable.other.palang",
+					"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b"
+				}
+			]
+		},
+		"prompt-body": {
+			"name": "meta.prompt-body.palang",
+			"begin": "(?<=\\bprompt\\s+\\w*\\s*\\(.*?\\)\\s*->\\s*.*?\\s*\\{)",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.prompt-body.begin.palang"
+				}
+			},
+			"end": "(\\})",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.prompt-body.end.palang"
+				}
+			},
+			"patterns": [
+				{
+					"name": "variable.other.placeholder.palang",
+					"match": "@\\{[^}]+\\}"
+				},
+				{
+					"name": "string.unquoted.prompt-content.palang",
+					"match": "[^@\\{]+"
+				}
+			]
+		},
+		"model-body": {
+			"name": "meta.model-body.palang",
+			"begin": "(?<=\\bmodel\\s+\\w*\\s*\\{)",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.model-body.begin.palang"
+				}
+			},
+			"end": "(\\})",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.model-body.end.palang"
+				}
+			},
+			"patterns": [
+				{
+					"name": "variable.other.placeholder.palang",
+					"match": "@\\{[^}]+\\}"
+				},
+				{
+					"name": "string.unquoted.model-content.palang",
+					"match": "[^@\\{]+"
+				}
+			]
+		}
+	},
+	"scopeName": "source.palang"
+}

--- a/palang-vs-code-syntax-highlighting/vsc-extension-quickstart.md
+++ b/palang-vs-code-syntax-highlighting/vsc-extension-quickstart.md
@@ -1,0 +1,29 @@
+# Welcome to your VS Code Extension
+
+## What's in the folder
+
+* This folder contains all of the files necessary for your extension.
+* `package.json` - this is the manifest file in which you declare your language support and define the location of the grammar file that has been copied into your extension.
+* `syntaxes/palang.tmLanguage.json` - this is the Text mate grammar file that is used for tokenization.
+* `language-configuration.json` - this is the language configuration, defining the tokens that are used for comments and brackets.
+
+## Get up and running straight away
+
+* Make sure the language configuration settings in `language-configuration.json` are accurate.
+* Press `F5` to open a new window with your extension loaded.
+* Create a new file with a file name suffix matching your language.
+* Verify that syntax highlighting works and that the language configuration settings are working.
+
+## Make changes
+
+* You can relaunch the extension from the debug toolbar after making changes to the files listed above.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
+
+## Add more language features
+
+* To add features such as IntelliSense, hovers and validators check out the VS Code extenders documentation at https://code.visualstudio.com/docs
+
+## Install the Palang extension
+
+* To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
+* To share your extension with the world, read on https://code.visualstudio.com/docs about publishing an extension.


### PR DESCRIPTION
### What's changed
Implemented minimal syntax highlighting VS Code extension for the Palang programming language.

Here are examples:

### Defining models
![Screenshot from 2024-08-19 17-51-57](https://github.com/user-attachments/assets/4ff6bed3-741a-4131-82f6-bfa48019f19f)

### Defining prompts and functions
![Screenshot from 2024-08-19 17-51-46](https://github.com/user-attachments/assets/80264b20-6d54-4b8e-bb07-5e41d66c1068)
