### PR TITLE
Added publisher and repository to vs code syntax highlighting extension

### DIFF
--- a/palang-vs-code-syntax-highlighting/package.json
+++ b/palang-vs-code-syntax-highlighting/package.json
@@ -3,6 +3,11 @@
   "displayName": "Palang",
   "description": "The Palang programming language empowers developers to bootstrap LLM projects quickly and efficiently and to share LLM logic between projects.",
   "version": "0.0.1",
+  "publisher": "Thinking-Dragon",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Thinking-Dragon/palang/tree/main/palang-vs-code-syntax-highlighting"
+  },
   "engines": {
     "vscode": "^1.92.0"
   },
@@ -10,16 +15,26 @@
     "Programming Languages"
   ],
   "contributes": {
-    "languages": [{
-      "id": "palang",
-      "aliases": ["Palang", "palang"],
-      "extensions": [".palang",".plg"],
-      "configuration": "./language-configuration.json"
-    }],
-    "grammars": [{
-      "language": "palang",
-      "scopeName": "source.palang",
-      "path": "./syntaxes/palang.tmLanguage.json"
-    }]
+    "languages": [
+      {
+        "id": "palang",
+        "aliases": [
+          "Palang",
+          "palang"
+        ],
+        "extensions": [
+          ".palang",
+          ".plg"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "palang",
+        "scopeName": "source.palang",
+        "path": "./syntaxes/palang.tmLanguage.json"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Added:
```json
"publisher": "Thinking-Dragon",
  "repository": {
    "type": "git",
    "url": "https://github.com/Thinking-Dragon/palang/tree/main/palang-vs-code-syntax-highlighting"
  },
```

To `package.json`.

These fields are wanted when publishing to the VS Code marketplace.