### PR TITLE
[Feature] Implemented basic virtual machine

### DIFF
--- a/palang-cli/Cargo.toml
+++ b/palang-cli/Cargo.toml
@@ -5,6 +5,14 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.16", features = ["derive"] }
+dirs = "5.0.1"
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
+serde_yaml = "0.9.34"
+tokio = { version = "1.39.3", features = ["full"] }
 
 [dependencies.palang-compiler]
 path = "../palang-compiler"
+
+[dependencies.palang-virtual-machine]
+path = "../palang-virtual-machine"

--- a/palang-cli/src/profile.rs
+++ b/palang-cli/src/profile.rs
@@ -1,0 +1,58 @@
+use std::{fs, path::PathBuf};
+
+use palang_virtual_machine::llm::model_settings::ModelSettings;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Profile {
+    pub llm: String,
+    pub model: String,
+    pub temperature: u32,
+    pub max_tokens: u32,
+}
+
+pub fn load_profile(file_path: &PathBuf) -> Result<Profile, String> {
+    let raw_profile: String = fs::read_to_string(file_path)
+                                 .map_err(|e| e.to_string())?;
+    let profile: Profile = serde_yaml::from_str(&raw_profile)
+                                      .map_err(|e| e.to_string())?;
+
+    Ok(profile)
+}
+
+pub fn load_profile_from_directory(file_name: &String, directory: &Option<PathBuf>) -> Result<Profile, String> {
+    let file_name_with_extension: String = format!("{}.yaml", file_name);
+    match directory {
+        Some(directory_path) => {
+            let file_path: PathBuf = directory_path.join(file_name_with_extension);
+            return load_profile(&file_path);
+        },
+        None => {
+            if let Some(home_directory) = dirs::home_dir() {
+                let local_profile_path: PathBuf = home_directory.join(".local/share/palang/profiles")
+                                                                .join(file_name_with_extension.clone());
+                if local_profile_path.exists() {
+                    return load_profile(&local_profile_path);
+                }
+            }
+
+            let global_profile_path = PathBuf::from("/usr/share/palang/profiles")
+                                                       .join(file_name_with_extension);
+            if global_profile_path.exists() {
+                return load_profile(&global_profile_path);
+            }
+        },
+    }
+
+    return Err(format!("Profile {} was not found.", file_name));
+}
+
+impl Profile {
+    pub fn get_model_settings(&self) -> ModelSettings {
+        ModelSettings {
+            model: self.model.clone(),
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+        }
+    }
+}

--- a/palang-virtual-machine/Cargo.toml
+++ b/palang-virtual-machine/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "palang-virtual-machine"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+reqwest = { version = "0.12.7", features = ["json"] }
+serde_json = "1.0.127"
+tokio = { version = "1.39.3", features = ["full"] }

--- a/palang-virtual-machine/src/assembly/assemblies_cache.rs
+++ b/palang-virtual-machine/src/assembly/assemblies_cache.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+use super::{assembly::Assembly, model::Model, task::Task};
+
+pub struct AssembliesCache {
+    assemblies: HashMap<String, Assembly>,
+    models_index: HashMap<String, String>,
+    prompts_index: HashMap<String, String>,
+    functions_index: HashMap<String, String>,
+}
+
+impl AssembliesCache {
+    pub fn new() -> Self {
+        AssembliesCache {
+            assemblies: HashMap::new(),
+            models_index: HashMap::new(),
+            prompts_index: HashMap::new(),
+            functions_index: HashMap::new(),
+        }
+    }
+
+    pub fn get_model(&self, model: &String) -> Option<Model> {
+        if let Some(assembly_name) = self.models_index.get(model) {
+            if let Some(assembly) = self.assemblies.get(assembly_name) {
+                return match assembly.models.get(model) {
+                    Some(model) => Some(model.clone()),
+                    None => None,
+                };
+            }
+        }
+
+        return None;
+    }
+
+    pub fn get_task(&self, task: &String) -> Option<Task> {
+        if let Some(assembly_name) = self.prompts_index.get(task) {
+            if let Some(assembly) = self.assemblies.get(assembly_name) {
+                return match assembly.prompts.get(task) {
+                    Some(prompt) => Some(Task::Prompt(prompt.clone())),
+                    None => None,
+                };
+            }
+        }
+
+        if let Some(assembly_name) = self.functions_index.get(task) {
+            if let Some(assembly) = self.assemblies.get(assembly_name) {
+                return match assembly.functions.get(task) {
+                    Some(function) => Some(Task::Function(function.clone())),
+                    None => None,
+                };
+            }
+        }
+
+        return None;
+    }
+
+    pub fn load(&mut self, assembly: &Assembly) {
+        self.assemblies.insert(assembly.name.clone(), assembly.clone());
+
+        for (key, _) in &assembly.models {
+            self.models_index.insert(key.clone(), assembly.name.clone());
+        }
+
+        for (key, _) in &assembly.prompts {
+            self.prompts_index.insert(key.clone(), assembly.name.clone());
+        }
+
+        for (key, _) in &assembly.functions {
+            self.functions_index.insert(key.clone(), assembly.name.clone());
+        }
+    }
+}

--- a/palang-virtual-machine/src/assembly/assembly.rs
+++ b/palang-virtual-machine/src/assembly/assembly.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+
+use super::{function::Function, model::Model, prompt::Prompt};
+
+#[derive(Debug, Clone)]
+pub struct Assembly {
+    pub name: String,
+    pub models: HashMap<String, Model>,
+    pub prompts: HashMap<String, Prompt>,
+    pub functions: HashMap<String, Function>
+}
+
+impl Assembly {
+    pub fn new() -> Self {
+        Assembly {
+            name: String::new(),
+            models: HashMap::new(),
+            prompts: HashMap::new(),
+            functions: HashMap::new(),
+        }
+    }
+}

--- a/palang-virtual-machine/src/assembly/function.rs
+++ b/palang-virtual-machine/src/assembly/function.rs
@@ -1,0 +1,9 @@
+use super::{instruction::Instruction, parameter::Parameter};
+
+#[derive(Debug, Clone)]
+pub struct Function {
+    pub name: String,
+    pub parameters: Vec<Parameter>,
+    pub return_type: String,
+    pub instructions: Vec<Instruction>,
+}

--- a/palang-virtual-machine/src/assembly/instruction.rs
+++ b/palang-virtual-machine/src/assembly/instruction.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone)]
+pub enum Instruction {
+    Assign(String, String),
+    Invoke(String, Vec<String>),
+    Return(String),
+}

--- a/palang-virtual-machine/src/assembly/loader.rs
+++ b/palang-virtual-machine/src/assembly/loader.rs
@@ -1,0 +1,199 @@
+use super::{assembly::Assembly, function::Function, instruction::Instruction, model::Model, parameter::Parameter, prompt::Prompt};
+
+struct AssemblyReader {
+    lines: Vec<String>,
+    cursor: usize,
+}
+
+impl AssemblyReader {
+    pub fn new(source: &String) -> Self {
+        AssemblyReader {
+            lines: source.lines().map(str::to_string).collect(),
+            cursor: 0,
+        }
+    }
+
+    pub fn reached_end(&self) -> bool {
+        self.cursor >= self.lines.len()
+    }
+
+    pub fn next_instruction(&mut self) -> Result<(String, Vec<String>), String> {
+        let line = self.peek_instruction()?;
+        self.cursor += 1;
+
+        Ok(line)
+    }
+
+    pub fn peek_instruction(&self) -> Result<(String, Vec<String>), String> {
+        if self.reached_end() {
+            return Err("Tried to get line after end of assembly was reached".to_string());
+        }
+
+        let line: String = self.lines.get(self.cursor).unwrap().clone();
+        let tokens: Vec<String> = line.split(" ").map(str::to_string).collect();
+
+        if tokens.is_empty() {
+            return Err("Line is empty".to_string());
+        }
+
+        Ok((tokens.first().unwrap().to_string(), tokens[1..].into()))
+    }
+
+    pub fn next_line(&mut self) -> Result<String, String> {
+        if self.reached_end() {
+            return Err("Tried to get line after end of assembly was reached".to_string());
+        }
+
+        let line: String = self.lines.get(self.cursor).unwrap().clone();
+        self.cursor += 1;
+
+        Ok(line)
+    }
+
+    pub fn next(&mut self) {
+        self.cursor += 1;
+    }
+
+    pub fn expect(&mut self, instruction: &str) -> Result<Vec<String>, String> {
+        let (next_instruction, parameters) = self.next_instruction()?;
+
+        if next_instruction.as_str() == instruction {
+            Ok(parameters)
+        }
+        else {
+            Err(format!("Expected {}, found {}", instruction, next_instruction))
+        }
+    }
+}
+
+pub fn load_assembly(source: &String) -> Result<Assembly, String> {
+    let mut assembly: Assembly = Assembly::new();
+    let mut reader: AssemblyReader = AssemblyReader::new(source);
+
+    while !reader.reached_end() {
+        match reader.next_instruction() {
+            Ok((instruction, parameters)) => {
+                match instruction.as_str() {
+                    "MODULE" => {
+                        assembly.name = parameters.get(0).unwrap().clone();
+                    },
+                    "MODEL" => {
+                        let name: String = parameters.get(0).unwrap().clone();
+                        let mut text: String = String::new();
+
+                        reader.expect("START")?;
+                        loop {
+                            let (line_instruction, _) = reader.peek_instruction()?;
+                            if line_instruction == "END" {
+                                break;
+                            }
+
+                            text += reader.next_line()?.as_str();
+                        }
+                        reader.next();
+
+                        assembly.models.insert(
+                            name.clone(),
+                            Model { name, text }
+                        );
+                    },
+                    "PROMPT" => {
+                        let name: String = parameters.get(0).unwrap().clone();
+                        let mut text: String = String::new();
+
+                        let arguments: Vec<Parameter> = reader
+                            .expect("ARGUMENTS")?[0..]
+                            .iter()
+                            .map(|argument| Parameter { name: argument.clone() })
+                            .collect();
+                        let returns: String = reader.expect("RETURNS")?.get(0).unwrap().clone();
+
+                        reader.expect("START")?;
+                        loop {
+                            let (line_instruction, _) = reader.peek_instruction()?;
+                            if line_instruction == "END" {
+                                break;
+                            }
+
+                            text += reader.next_line()?.as_str();
+                        }
+                        reader.next();
+
+                        assembly.prompts.insert(
+                            name.clone(),
+                            Prompt {
+                                name,
+                                parameters: arguments,
+                                return_type: returns,
+                                text,
+                            }
+                        );
+                    },
+                    "FUNCTION" => {
+                        let name: String = parameters.get(0).unwrap().clone();
+                        let mut instructions: Vec<Instruction> = Vec::new();
+
+                        let arguments: Vec<Parameter> = reader
+                            .expect("ARGUMENTS")?[0..]
+                            .iter()
+                            .map(|argument| Parameter { name: argument.clone() })
+                            .collect();
+                        let returns: String = reader.expect("RETURNS")?.get(0).unwrap().clone();
+
+                        reader.expect("START")?;
+                        loop {
+                            let (line_instruction, line_parameters) = reader.peek_instruction()?;
+                            match line_instruction.as_str() {
+                                "END" => {
+                                    break;
+                                },
+                                "ASSIGN" => {
+                                    instructions.push(
+                                        Instruction::Assign(
+                                            line_parameters.get(0).unwrap().to_string(),
+                                            line_parameters.get(1).unwrap().to_string(),
+                                        )
+                                    );
+                                },
+                                "INVOKE" => {
+                                    instructions.push(
+                                        Instruction::Invoke(
+                                            line_parameters.get(0).unwrap().clone(),
+                                            line_parameters[1..].into(),
+                                        )
+                                    );
+                                },
+                                "RETURN" => {
+                                    instructions.push(
+                                        Instruction::Return(
+                                            line_parameters.get(0).unwrap().clone(),
+                                        )
+                                    )
+                                },
+                                _ => {},
+                            }
+                            reader.next();
+                        }
+                        reader.next();
+
+                        assembly.functions.insert(
+                            name.clone(),
+                            Function {
+                                name,
+                                parameters: arguments,
+                                return_type: returns,
+                                instructions,
+                            }
+                        );
+                    },
+                    _ => {},
+                }
+            },
+            Err(_) => {
+                continue;
+            }
+        }
+    }
+
+    Ok(assembly)
+}

--- a/palang-virtual-machine/src/assembly/mod.rs
+++ b/palang-virtual-machine/src/assembly/mod.rs
@@ -1,0 +1,9 @@
+pub mod parameter;
+pub mod instruction;
+pub mod model;
+pub mod prompt;
+pub mod function;
+pub mod task;
+pub mod assembly;
+pub mod assemblies_cache;
+pub mod loader;

--- a/palang-virtual-machine/src/assembly/model.rs
+++ b/palang-virtual-machine/src/assembly/model.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone)]
+pub struct Model {
+    pub name: String,
+    pub text: String,
+}

--- a/palang-virtual-machine/src/assembly/parameter.rs
+++ b/palang-virtual-machine/src/assembly/parameter.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, Clone)]
+pub struct Parameter {
+    pub name: String,
+}

--- a/palang-virtual-machine/src/assembly/prompt.rs
+++ b/palang-virtual-machine/src/assembly/prompt.rs
@@ -1,0 +1,9 @@
+use super::parameter::Parameter;
+
+#[derive(Debug, Clone)]
+pub struct Prompt {
+    pub name: String,
+    pub parameters: Vec<Parameter>,
+    pub return_type: String,
+    pub text: String,
+}

--- a/palang-virtual-machine/src/assembly/task.rs
+++ b/palang-virtual-machine/src/assembly/task.rs
@@ -1,0 +1,6 @@
+use super::{function::Function, prompt::Prompt};
+
+pub enum Task {
+    Prompt(Prompt),
+    Function(Function),
+}

--- a/palang-virtual-machine/src/lib.rs
+++ b/palang-virtual-machine/src/lib.rs
@@ -1,0 +1,40 @@
+use std::{fs, path::PathBuf};
+
+use assembly::{assembly::Assembly, loader::load_assembly};
+use llm::llm::LargeLanguageModel;
+use virtualization::virtual_machine::VirtualMachine;
+
+pub mod assembly;
+pub mod virtualization;
+pub mod llm;
+
+pub fn load_assembly_file(file: &PathBuf) -> Result<Assembly, String> {
+    let assembly_code: String = fs::read_to_string(file)
+                                   .map_err(|e| e.to_string())?;
+
+    load_assembly(&assembly_code)
+}
+
+pub fn choose_llm(llm: &String) -> Result<LargeLanguageModel, String> {
+    match llm.to_lowercase().as_str() {
+        "groq" => {
+            let authorization_token: String = std::env::var("GROQ_AUTHORIZATION_TOKEN")
+                                                       .map_err(|e| e.to_string())?;
+            Ok(LargeLanguageModel::new_groq(&authorization_token))
+        },
+        "ollama" => {
+            let base_url: String = std::env::var("OLLAMA_BASE_URL")
+                                            .map_err(|e| e.to_string())?;
+            Ok(LargeLanguageModel::new_ollama(&base_url))
+        },
+        _ => Err(format!("Large Language Model \"{}\" not found", llm.to_lowercase())),
+    }
+}
+
+pub fn boot_machine(llm: &LargeLanguageModel) -> VirtualMachine {
+    let vm: VirtualMachine = VirtualMachine::new(llm);
+
+    // Todo: load std assemblies into vm.
+
+    vm
+}

--- a/palang-virtual-machine/src/llm/groq_llm.rs
+++ b/palang-virtual-machine/src/llm/groq_llm.rs
@@ -1,0 +1,76 @@
+use reqwest::{header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE}, Client};
+use serde_json::{json, Value};
+
+use super::{invokable_llm::InvokableLargeLanguageModel, model_settings::ModelSettings};
+
+#[derive(Clone)]
+pub struct GroqLargeLanguageModel {
+    client: Client,
+    authorization_token: String,
+}
+
+impl InvokableLargeLanguageModel for GroqLargeLanguageModel {
+    async fn invoke(
+        &self,
+        system: &String,
+        prompt: &String,
+        settings: &ModelSettings,
+    ) -> Result<String, String> {
+        let body = json!({
+            "messages": [
+                {
+                    "role": "system",
+                    "content": system,
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                }
+            ],
+            "model": settings.model,
+            "temperature": settings.temperature,
+            "max_tokens": settings.max_tokens,
+            "top_p": 1,
+            "stream": false,
+            "stop": null,
+        });
+
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(AUTHORIZATION,
+            HeaderValue::from_str(
+                &format!("Bearer {}", self.authorization_token).as_str()
+            ).map_err(|e| e.to_string())?
+        );
+
+        let response: Value = self.client
+            .post("https://api.groq.com/openai/v1/chat/completions")
+            .headers(headers)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?
+            .json()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Extract the content from the first choice's message
+        response
+            .get("choices")
+            .and_then(|choices| choices.get(0))
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("content"))
+            .and_then(|content| content.as_str())
+            .map(String::from)
+            .ok_or_else(|| "Failed to extract content from response".to_string())
+    }
+}
+
+impl GroqLargeLanguageModel {
+    pub fn new(authorization_token: &String) -> Self {
+        GroqLargeLanguageModel {
+            client: Client::new(),
+            authorization_token: authorization_token.clone(),
+        }
+    }
+}

--- a/palang-virtual-machine/src/llm/invokable_llm.rs
+++ b/palang-virtual-machine/src/llm/invokable_llm.rs
@@ -1,0 +1,10 @@
+use super::model_settings::ModelSettings;
+
+pub trait InvokableLargeLanguageModel {
+    fn invoke(
+        &self,
+        system: &String,
+        prompt: &String,
+        settings: &ModelSettings,
+    ) -> impl std::future::Future<Output = Result<String, String>> + Send;
+}

--- a/palang-virtual-machine/src/llm/llm.rs
+++ b/palang-virtual-machine/src/llm/llm.rs
@@ -1,0 +1,29 @@
+use super::{groq_llm::GroqLargeLanguageModel, invokable_llm::InvokableLargeLanguageModel, model_settings::ModelSettings, ollama_llm::OllamaLargeLanguageModel};
+
+#[derive(Clone)]
+pub enum LargeLanguageModel {
+    Groq(GroqLargeLanguageModel),
+    Ollama(OllamaLargeLanguageModel),
+}
+
+impl LargeLanguageModel {
+    pub fn new_groq(authorization_token: &String) -> Self {
+        LargeLanguageModel::Groq(GroqLargeLanguageModel::new(authorization_token))
+    }
+
+    pub fn new_ollama(base_url: &String) -> Self {
+        LargeLanguageModel::Ollama(OllamaLargeLanguageModel::new(base_url))
+    }
+
+    pub async fn invoke(
+        &self,
+        system: &String,
+        prompt: &String,
+        settings: &ModelSettings,
+    ) -> Result<String, String> {
+        match self {
+            LargeLanguageModel::Groq(llm) => llm.invoke(system, prompt, settings).await,
+            LargeLanguageModel::Ollama(llm) => llm.invoke(system, prompt, settings).await,
+        }
+    }
+}

--- a/palang-virtual-machine/src/llm/mod.rs
+++ b/palang-virtual-machine/src/llm/mod.rs
@@ -1,0 +1,5 @@
+pub mod model_settings;
+pub mod invokable_llm;
+pub mod llm;
+pub mod groq_llm;
+pub mod ollama_llm;

--- a/palang-virtual-machine/src/llm/model_settings.rs
+++ b/palang-virtual-machine/src/llm/model_settings.rs
@@ -1,0 +1,5 @@
+pub struct ModelSettings {
+    pub model: String,
+    pub temperature: u32,
+    pub max_tokens: u32,
+}

--- a/palang-virtual-machine/src/llm/ollama_llm.rs
+++ b/palang-virtual-machine/src/llm/ollama_llm.rs
@@ -1,0 +1,67 @@
+use reqwest::{Client, header::{HeaderMap, HeaderValue, CONTENT_TYPE}};
+use serde_json::{json, Value};
+
+use super::{invokable_llm::InvokableLargeLanguageModel, model_settings::ModelSettings};
+
+#[derive(Clone)]
+pub struct OllamaLargeLanguageModel {
+    client: Client,
+    base_url: String,
+}
+
+impl InvokableLargeLanguageModel for OllamaLargeLanguageModel {
+    async fn invoke(
+        &self,
+        system: &String,
+        prompt: &String,
+        settings: &ModelSettings,
+    ) -> Result<String, String> {
+        let body = json!({
+            "messages": [
+                {
+                    "role": "system",
+                    "content": system,
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                }
+            ],
+            "model": settings.model,
+            "temperature": settings.temperature,
+            "max_tokens": settings.max_tokens,
+            "stream": false,
+        });
+
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let response: Value = self.client
+            .post(format!("{}/v1/chat/completions", self.base_url))
+            .headers(headers)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?
+            .json()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Extract the content from the message
+        response
+            .get("message")
+            .and_then(|message| message.get("content"))
+            .and_then(|content| content.as_str())
+            .map(String::from)
+            .ok_or_else(|| "Failed to extract content from response".to_string())
+    }
+}
+
+impl OllamaLargeLanguageModel {
+    pub fn new(base_url: &String) -> Self {
+        OllamaLargeLanguageModel {
+            client: Client::new(),
+            base_url: base_url.clone(),
+        }
+    }
+}

--- a/palang-virtual-machine/src/virtualization/function_runner.rs
+++ b/palang-virtual-machine/src/virtualization/function_runner.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+
+use crate::{assembly::{function::Function, instruction::Instruction}, llm::model_settings::ModelSettings};
+
+use super::virtual_machine::VirtualMachine;
+
+pub async fn run_function<'a>(
+    function_info: &'a Function,
+    parameters: &Vec<String>,
+    model_settings: &ModelSettings,
+    vm: &'a mut VirtualMachine,
+) -> Result<String, String> {
+    let mut runner: FunctionRunner = FunctionRunner {
+        model_settings,
+        vm,
+        function_info,
+        variables: HashMap::new(),
+        invocation_registry: None,
+        program_counter: 0,
+    };
+
+    load_parameters_into_variables(&mut runner, function_info, parameters);
+
+    loop {
+        match runner.step().await {
+            StepResult::Ok => continue,
+            StepResult::Return(value) => return Ok(value),
+            StepResult::Err(e) => return Err(e),
+        }
+    }
+}
+
+fn load_parameters_into_variables(
+    runner: &mut FunctionRunner,
+    function_info: &Function,
+    parameters: &Vec<String>
+) {
+    for (
+        _, (parameter, value)
+    ) in function_info.parameters.iter().zip(parameters.iter()).enumerate() {
+        runner.variables.insert(parameter.name.to_string(), value.to_string());
+    }
+}
+
+pub struct FunctionRunner<'a> {
+    model_settings: &'a ModelSettings,
+    vm: &'a mut VirtualMachine,
+    function_info: &'a Function,
+    variables: HashMap<String, String>,
+    invocation_registry: Option<String>,
+    program_counter: usize,
+}
+
+enum StepResult {
+    Ok,
+    Return(String),
+    Err(String),
+}
+
+impl<'a> FunctionRunner<'a> {
+    async fn step(&mut self) -> StepResult {
+        match self.function_info.instructions.get(self.program_counter) {
+            Some(instruction) => {
+                match instruction {
+                    Instruction::Assign(to, from) => {
+                        if from == "@invocation_registry" {
+                            match &self.invocation_registry {
+                                Some(value) => {
+                                    self.variables.insert(to.clone(), value.clone());
+                                },
+                                None => {
+                                    return StepResult::Err("Tried to assign value from empty invocation registry".to_string());
+                                },
+                            }
+                        }
+                        else {
+                            match self.variables.get(from) {
+                                Some(value) => {
+                                    self.variables.insert(to.clone(), value.clone());
+                                },
+                                None => {
+                                    return StepResult::Err(format!("Variable {} not found", from));
+                                },
+                            }
+                        }
+
+                        self.program_counter += 1;
+                    },
+                    Instruction::Invoke(task, arguments) => {
+                        let argument_values: Vec<String> = arguments
+                            .iter()
+                            .map(|argument_name| self.variables.get(argument_name).unwrap().clone())
+                            .collect();
+
+                        self.invocation_registry = match self.vm.execute(
+                            task,
+                            &argument_values,
+                            &self.model_settings,
+                        ).await.await {
+                            Ok(value) => Some(value.clone()),
+                            Err(_) => None,
+                        };
+
+                        self.program_counter += 1;
+                    },
+                    Instruction::Return(to_return) => {
+                        match self.variables.get(to_return) {
+                            Some(value) => {
+                                return StepResult::Return(value.clone());
+                            },
+                            None => {
+                                return StepResult::Return(to_return.clone());
+                            },
+                        }
+                    },
+                }
+            },
+            None => {
+                return StepResult::Err("Tried to execute instruction outside of function bounds.".to_string())
+            }
+        }
+        StepResult::Ok
+    }
+}

--- a/palang-virtual-machine/src/virtualization/mod.rs
+++ b/palang-virtual-machine/src/virtualization/mod.rs
@@ -1,0 +1,2 @@
+pub mod function_runner;
+pub mod virtual_machine;

--- a/palang-virtual-machine/src/virtualization/virtual_machine.rs
+++ b/palang-virtual-machine/src/virtualization/virtual_machine.rs
@@ -1,0 +1,99 @@
+use std::{future::Future, pin::Pin};
+
+use crate::{
+    assembly::{
+        assemblies_cache::AssembliesCache,
+        assembly::Assembly,
+        function::Function,
+        prompt::Prompt,
+        task::Task
+    },
+    llm::{llm::LargeLanguageModel, model_settings::ModelSettings}
+};
+
+use super::function_runner::run_function;
+
+pub struct VirtualMachine {
+    assemblies: AssembliesCache,
+    llm: LargeLanguageModel,
+}
+
+impl VirtualMachine {
+    pub fn new(llm: &LargeLanguageModel) -> Self {
+        VirtualMachine {
+            assemblies: AssembliesCache::new(),
+            llm: llm.clone(),
+        }
+    }
+
+    pub fn load_assembly(&mut self, assembly: &Assembly) {
+        self.assemblies.load(assembly);
+    }
+
+    pub async fn execute<'a>(
+        &'a mut self,
+        task: &'a String,
+        parameters: &'a Vec<String>,
+        settings: &'a ModelSettings,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + 'a>> {
+        Box::pin(async move {
+            match self.assemblies.get_task(task) {
+                Some(task) => {
+                    match task {
+                        Task::Prompt(prompt) => {
+                            return self.execute_prompt(&prompt, parameters, settings).await;
+                        },
+                        Task::Function(function) => {
+                            return self.execute_function(&function, parameters, settings).await;
+                        },
+                    }
+                },
+                None => {
+                    return Err(format!("{} not found", task));
+                }
+            }
+        })
+    }
+
+    async fn execute_prompt(
+        &mut self,
+        prompt: &Prompt,
+        parameters: &Vec<String>,
+        settings: &ModelSettings,
+    ) -> Result<String, String> {
+        let system: String = "
+            You will reply with the wanted response only and nothing else.
+            You will not add any personal remark.
+            If you do not know the answer, you will say: 'unknown' and nothing else.
+            You will only end your response with a dot if your response is a sentence.
+            If your response is a name or a thing, you will not end it with a dot.
+        ".to_string();
+        let mut instructions: String = prompt.text.clone();
+
+        for (_, (parameter, value)) in prompt.parameters.iter().zip(parameters.iter()).enumerate() {
+            instructions = instructions.replace(
+                &format!("@{{{}}}", parameter.name),
+                &format!("{{parameter \"{}\": {}}}", parameter.name, value)
+            );
+        }
+
+        instructions += "\n--- Parameter formats ---\n";
+        for (_, (parameter, value)) in prompt.parameters.iter().zip(parameters.iter()).enumerate() {
+            instructions += &format!("Parameter \"{}\" is formatted as follows: {}\n", parameter.name, value);
+        }
+
+        let return_type_model: String = self.assemblies.get_model(&prompt.return_type).unwrap().text.clone();
+        instructions += &format!("Your response will be formatted as follows: {}", return_type_model);
+
+        self.llm.invoke(&system, &instructions, &settings).await
+    }
+
+    async fn execute_function(
+        &mut self,
+        function: &Function,
+        parameters: &Vec<String>,
+        model_settings: &ModelSettings,
+    ) -> Result<String, String> {
+        run_function(function, parameters, model_settings, self).await
+    }
+}


### PR DESCRIPTION
Minimal VM was implemented.
You can run _**prompts**_, which will be routed to LLMs depending on a profile you provide.
The profiles are `yaml` files formatted as follows:
```yaml
llm: groq
model: llama3-70b-8192
temperature: 1
max_tokens: 1024
```

The `palang` CLI will look for them by default in `~/.local/share/palang/profiles` then in `/usr/share/palang/profiles`.
If you provide the `--profiles-directory` argument to the CLI, it will look in your directory instead.

You can run **_functions_** with the following `palasm` instructions:
- ASSIGN target source
- INVOKE task arguments
- RETURN variable